### PR TITLE
Add notes about installing via Homebrew formula.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,6 +41,17 @@ If you can't compile because of this error: "'zipconf.h' file not found", try:
 
 	http://brew.sh/
 
+An unofficial formula is available at https://github.com/lifepillar/homebrew-appleii.
+Just tap the repository:
+
+    brew tap lifepillar/appleii
+
+After that, you may install OpenEmulator with just one command:
+
+    brew install openemulator
+
+The following instructions are needed only if you don't want to use the above formula.
+
 #### Install dependencies
 
 **Note:** if I missed any, follow my procedure: try to build, see which header file or library is


### PR DESCRIPTION
I have written a Homebrew formula to easily install OpenEmulator. I have tested it with OS X Lion and Yosemite and it works fine. This commit adds a note to INSTALL.md explaining how to install OpenEmulator using my Homebrew formula.